### PR TITLE
refactor: Set default canvas text font to Arial

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * @returns {Object} Un objeto con propiedades de texto: fontFace, fontWeight, maxWidth, textPadding, referenceFontSize.
      */
     const configureTextProperties = (ctx, canvasEl) => {
-        const fontFace = 'Arial Black'; // Familia de fuente base para el texto del meme.
+        const fontFace = 'Arial'; // Familia de fuente base para el texto del meme.
         const fontWeight = 'bold';   // Peso de la fuente base.
 
         ctx.fillStyle = 'white'; // Color de relleno del texto.


### PR DESCRIPTION
This commit updates script.js to use 'Arial' as the consistent font family for text drawn on the meme canvas.

The previous logic for dynamically changing the canvas font based on screen width (Arial Black for mobile, Arial for desktop) has been removed in favor of this simpler, unified approach as per your latest feedback.